### PR TITLE
Update to latest mannol commits

### DIFF
--- a/toxcore.podspec
+++ b/toxcore.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "toxcore"
-  s.version          = "0.0.0-641b0f-new-av-2"
+  s.version          = "0.0.0-63a82-new-av-3"
   s.summary          = "Cocoapods wrapper for toxcore"
   s.homepage         = "https://github.com/Antidote-for-Tox/toxcore"
   s.license          = 'GPLv3'


### PR DESCRIPTION
This change includes the codec fix from mannol.

toxcore for new toxav is now at https://github.com/mannol/toxcore/commit/e5ddc0af03d2852fbfb723a48e6e99dfbdb63a82
